### PR TITLE
BO: Fix SQL error if customers are shared

### DIFF
--- a/statsbestcustomers.php
+++ b/statsbestcustomers.php
@@ -172,7 +172,7 @@ class statsbestcustomers extends ModuleGrid
 		LEFT JOIN `'._DB_PREFIX_.'connections` co ON g.`id_guest` = co.`id_guest`
 		WHERE co.date_add BETWEEN '.$this->getDate()
             .Shop::addSqlRestriction(Shop::SHARE_CUSTOMER, 'c').
-            'GROUP BY c.`id_customer`, c.`lastname`, c.`firstname`, c.`email`';
+            ' GROUP BY c.`id_customer`, c.`lastname`, c.`firstname`, c.`email`';
 
         if (Validate::IsName($this->_sort)) {
             $this->query .= ' ORDER BY `'.bqSQL($this->_sort).'`';


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | dev |
| Description? | SQL error when doing the ajax request to grider.php from the best customers statistics page |
| Type? | bug fix |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? | Create two shops with the share customers settings enabled. Go the Best customers section, the SQL error will be visible in the result of the XHR request to the grider.php script. |
