### PR TITLE
Fix total value in best customer stats list view.

### DIFF
--- a/statsbestcustomers.php
+++ b/statsbestcustomers.php
@@ -155,10 +155,8 @@ class statsbestcustomers extends ModuleGrid
             c.`email`,
 			COUNT(co.`id_connections`) as totalVisits,
 			IFNULL((
-				SELECT ROUND(SUM(IFNULL(op.`amount`, 0) / cu.conversion_rate), 2)
+				SELECT ROUND(SUM(IFNULL(o.`total_paid_tax_incl`, 0) / o.conversion_rate), 2)
 				FROM `' . _DB_PREFIX_ . 'orders` o
-				LEFT JOIN `' . _DB_PREFIX_ . 'order_payment` op ON o.reference = op.order_reference
-				LEFT JOIN `' . _DB_PREFIX_ . 'currency` cu ON o.id_currency = cu.id_currency
 				WHERE o.id_customer = c.id_customer
 				AND o.invoice_date BETWEEN ' . $this->getDate() . '
 				AND o.valid


### PR DESCRIPTION
https://github.com/PrestaShop/PrestaShop/issues/31157

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This is a continuation of PrestaShop/Prestashop#31440 and PrestaShop/Prestashop#31104. This change fixes stats for the summary spent per customer value on the module stats list view. It also solves a potential issue with conversion rates, because it was using a conversion rate from currency and not from the order. Special thanks to @Hlavtox.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#31157.
| How to test?  | Go to Dashboard>Stats>Best customers>Summary spent (last column) and see proper values instead of zeros.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
